### PR TITLE
Add candidate form

### DIFF
--- a/application/src/common/api/candidateApi.ts
+++ b/application/src/common/api/candidateApi.ts
@@ -49,7 +49,7 @@ export const candidateApi = createApi({
         }),
         createCandidate: builder.mutation<Candidate, CreateCandidateRequest>({
             query: payload => ({
-                url: '/candidates',
+                url: '/candidates/',
                 method: 'POST',
                 body: payload
             }),

--- a/application/src/common/api/candidateApi.ts
+++ b/application/src/common/api/candidateApi.ts
@@ -65,7 +65,7 @@ export const candidateApi = createApi({
         }),
         deleteCandidate: builder.mutation<void, number>({
             query: candidateId => ({
-                url: `/candidates/${candidateId}/delete`,
+                url: `/candidates/${candidateId}/delete/`,
                 method: 'DELETE',
             }),
             invalidatesTags: ['Candidate']

--- a/application/src/common/api/candidateApi.ts
+++ b/application/src/common/api/candidateApi.ts
@@ -69,6 +69,10 @@ export const candidateApi = createApi({
                 method: 'DELETE',
             }),
             invalidatesTags: ['Candidate']
+        }),
+        getDepartments: builder.query({
+            query: () => ({ url: `/candidates/dept`}),
+            providesTags: ['Candidate']
         })
     })
 });
@@ -79,4 +83,5 @@ export const {
     useCreateCandidateMutation,
     useUpdateCandidateMutation,
     useDeleteCandidateMutation,
+    useGetDepartmentsQuery,
 } = candidateApi;

--- a/application/src/common/api/candidateApi.ts
+++ b/application/src/common/api/candidateApi.ts
@@ -6,13 +6,20 @@ import { SortingQueryParams } from 'common/models/sorting';
 import { customBaseQuery } from './customBaseQuery';
 import { QueryParamsBuilder } from './queryParamsBuilder';
 
+export interface CandidateFormData {
+    id?: number,
+    name: string;
+    email: string;
+    department: number;
+  };
+
 export type CreateCandidateRequest = Pick<
-    Candidate,
+    CandidateFormData,
     'name' | 'email' | 'department'
 >;
 
 export type UpdateCandidateRequest = Pick<
-    Candidate,
+    CandidateFormData,
     'id' | 'name' | 'email' | 'department'
 >;
 
@@ -57,7 +64,7 @@ export const candidateApi = createApi({
         }),
         updateCandidate: builder.mutation<Candidate, UpdateCandidateRequest>({
             query: ({ id, ...candidateUpdate }) => ({
-                url: `/candidates/${id}/update`,
+                url: `/candidates/${id}/update/`,
                 method: 'PUT',
                 body: candidateUpdate
             }),

--- a/application/src/common/models/candidate.ts
+++ b/application/src/common/models/candidate.ts
@@ -2,9 +2,12 @@ export interface Candidate {
     id: number,
     name: string,
     email: string,
-    department: {
-        deptName: string,
-        contact: string,
-        contactEmail: string,
-    },
+    department: Department,
+}
+
+export interface Department {
+    id?: number,
+    deptName: string,
+    contact: string,
+    contactEmail: string,
 }

--- a/application/src/features/candidates/Routes.tsx
+++ b/application/src/features/candidates/Routes.tsx
@@ -1,6 +1,6 @@
 import { Layout } from 'common/components/Layout';
 import { NotFoundView } from 'common/components/NotFoundView';
-import { CandidateListView, CreateCandidateView } from 'features/candidates/pages';
+import { CandidateListView, CreateCandidateView, UpdateCandidateView } from 'features/candidates/pages';
 import { FC } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
@@ -8,6 +8,7 @@ export const CandidateRoutes: FC = () => (
   <Layout>
     <Routes>
       <Route path="/create-candidate" element={<CreateCandidateView />} />
+      <Route path="/update-candidate/:id" element={<UpdateCandidateView />} />
       <Route path='/' element={<CandidateListView />} />
       <Route path='/*' element={<NotFoundView />} />
     </Routes>

--- a/application/src/features/candidates/Routes.tsx
+++ b/application/src/features/candidates/Routes.tsx
@@ -1,12 +1,13 @@
 import { Layout } from 'common/components/Layout';
 import { NotFoundView } from 'common/components/NotFoundView';
-import { CandidateListView  } from 'features/candidates/pages';
+import { CandidateListView, CreateCandidateView } from 'features/candidates/pages';
 import { FC } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 export const CandidateRoutes: FC = () => (
   <Layout>
     <Routes>
+      <Route path="/create-candidate" element={<CreateCandidateView />} />
       <Route path='/' element={<CandidateListView />} />
       <Route path='/*' element={<NotFoundView />} />
     </Routes>

--- a/application/src/features/candidates/components/candidateDetailForm.tsx
+++ b/application/src/features/candidates/components/candidateDetailForm.tsx
@@ -2,9 +2,12 @@ import * as yup from 'yup';
 import { FC, useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
-import { Candidate, ServerValidationErrors } from 'common/models';
+import { Candidate, ServerValidationErrors, Department } from 'common/models';
 import { addServerErrors } from 'common/error/utilities';
+import { Button, Col, Row } from 'react-bootstrap';
+import Form from 'react-bootstrap/form';
 import WithUnsavedChangesPrompt from 'common/components/WithUnsavedChangesPrompt';
+import { LoadingButton } from 'common/components/LoadingButton';
 import { yupResolver } from '@hookform/resolvers/yup';
 
 export type FormData = Pick<Candidate, 'name' | 'email' | 'department'>;
@@ -16,6 +19,7 @@ export type Props = {
     onSubmit: (data: FormData) => void;
     onCancel: () => void;
     serverValidationErrors: ServerValidationErrors<FormData> | null;
+    departmentList: Department[];
 };
 
 const isBlank = (val:string) => !val || !val.trim();
@@ -31,7 +35,8 @@ export const CandidateDetailForm: FC<Props> = ({
     defaultValues = {},
     onSubmit,
     submitButtonLabel = 'Submit',
-    serverValidationErrors
+    serverValidationErrors,
+    departmentList
 }) => {
     const {
         register,
@@ -55,10 +60,45 @@ export const CandidateDetailForm: FC<Props> = ({
           addServerErrors(serverValidationErrors, setError);
         }
       }, [serverValidationErrors, setError]);
+      console.log('depts', departmentList);
 
       return (
         <WithUnsavedChangesPrompt when={isDirty && !(isSubmitting || isSubmitted)}>
-
+          <Form>
+            <Row className='mb-2'>
+              <Col xs={12} md={6}>
+                <Form.Group controlId='create-candidate-form-agent-name'>
+                  <Form.Label>Name</Form.Label>
+                  <Form.Control type='text' {...register('name')} isInvalid={!!errors.name} />
+                  <Form.Control.Feedback type='invalid'>{errors.name?.message}</Form.Control.Feedback>
+                </Form.Group>
+              </Col>
+              <Col xs={12} md={6}>
+                <Form.Group>
+                  <Form.Label>Email</Form.Label>
+                  <Form.Control type='email' {...register('email')} isInvalid={!!errors.email} />
+                  <Form.Control.Feedback type='invalid'>{errors.email?.message}</Form.Control.Feedback>
+                </Form.Group>
+              </Col>
+            </Row>
+            <Row className='mb-2'>
+              <Col xs={12} md={6}>
+                <Form.Group>
+                  <Form.Label>Department</Form.Label>
+                  <Form.Select>
+                    {departmentList.map(department => {
+                      return <option key={department.deptName}>{department.deptName}</option>
+                    })}
+                  </Form.Select>
+                </Form.Group>
+              </Col>
+            </Row>
+            <div className="mt-3">
+              <LoadingButton type='submit' as={Button} disabled={isValid} loading={isSubmitting}>
+                {submitButtonLabel}
+              </LoadingButton>
+            </div>
+          </Form>
         </WithUnsavedChangesPrompt>
       );
 }

--- a/application/src/features/candidates/components/candidateDetailForm.tsx
+++ b/application/src/features/candidates/components/candidateDetailForm.tsx
@@ -60,11 +60,15 @@ export const CandidateDetailForm: FC<Props> = ({
           addServerErrors(serverValidationErrors, setError);
         }
       }, [serverValidationErrors, setError]);
-      console.log('depts', departmentList);
+      console.log('depts', departmentList, 'errors', errors);
+
+      const preSubmit = (data: FormData) => {
+        onSubmit(data);
+      }
 
       return (
         <WithUnsavedChangesPrompt when={isDirty && !(isSubmitting || isSubmitted)}>
-          <Form>
+          <Form onSubmit={handleSubmit(preSubmit)}>
             <Row className='mb-2'>
               <Col xs={12} md={6}>
                 <Form.Group controlId='create-candidate-form-agent-name'>
@@ -87,14 +91,14 @@ export const CandidateDetailForm: FC<Props> = ({
                   <Form.Label>Department</Form.Label>
                   <Form.Select>
                     {departmentList.map(department => {
-                      return <option key={department.deptName}>{department.deptName}</option>
+                      return <option key={department.deptName} value={department.id}>{department.deptName}</option>
                     })}
                   </Form.Select>
                 </Form.Group>
               </Col>
             </Row>
             <div className="mt-3">
-              <LoadingButton type='submit' as={Button} disabled={isValid} loading={isSubmitting}>
+              <LoadingButton type='submit' as={Button} disabled={!isValid} loading={isSubmitting}>
                 {submitButtonLabel}
               </LoadingButton>
             </div>

--- a/application/src/features/candidates/components/candidateDetailForm.tsx
+++ b/application/src/features/candidates/components/candidateDetailForm.tsx
@@ -29,6 +29,7 @@ const schema = yup.object().shape({
     name: yup.string().required('Name is required'),
     email: yup.string().email().required('Email is required'),
     department: yup.number(),
+    id: yup.number(),
 });
 
 export const CandidateDetailForm: FC<Props> = ({
@@ -60,7 +61,7 @@ export const CandidateDetailForm: FC<Props> = ({
           addServerErrors(serverValidationErrors, setError);
         }
       }, [serverValidationErrors, setError]);
-      console.log('depts', departmentList, 'errors', errors);
+      console.log('depts', departmentList, 'errors', errors, isValid);
 
       const preSubmit = (data: FormData) => {
         onSubmit(data);

--- a/application/src/features/candidates/components/candidateDetailForm.tsx
+++ b/application/src/features/candidates/components/candidateDetailForm.tsx
@@ -10,10 +10,17 @@ import WithUnsavedChangesPrompt from 'common/components/WithUnsavedChangesPrompt
 import { LoadingButton } from 'common/components/LoadingButton';
 import { yupResolver } from '@hookform/resolvers/yup';
 
-export type FormData = Pick<Candidate, 'name' | 'email' | 'department'>;
+export interface CandidateFormData {
+  id?: number;
+  name: string;
+  email: string;
+  department: number;
+};
+
+export type FormData = Pick<CandidateFormData, 'name' | 'email' | 'department'>;
 
 export type Props = {
-    defaultValues?: FormData;
+    defaultValues?: CandidateFormData;
     submitButtonLabel?: string;
     cancelButtonLabel?: string;
     onSubmit: (data: FormData) => void;
@@ -61,7 +68,6 @@ export const CandidateDetailForm: FC<Props> = ({
           addServerErrors(serverValidationErrors, setError);
         }
       }, [serverValidationErrors, setError]);
-      console.log('depts', departmentList, 'errors', errors, isValid);
 
       const preSubmit = (data: FormData) => {
         onSubmit(data);

--- a/application/src/features/candidates/pages/CandidateListView.tsx
+++ b/application/src/features/candidates/pages/CandidateListView.tsx
@@ -41,7 +41,6 @@ export const CandidateListView: FC = () => {
     addSearchText,
   } = usePSFQuery<PaginatedResult<Candidate>>(useGetCandidatesQuery);
   const deptResults = usePSFQuery<PaginatedResult<Department>>(useGetDepartmentsQuery);
-  // console.log('dept results', deptResults);
   const departments = useMemo(() => deptResults.data?.results ?? [], [deptResults.data] )
   const candidates = useMemo(() => data?.results ?? [], [data]);
   const { columns, data: tableData } = useCandidateTableData(candidates);

--- a/application/src/features/candidates/pages/CandidateListView.tsx
+++ b/application/src/features/candidates/pages/CandidateListView.tsx
@@ -14,8 +14,8 @@ import { CreateButton } from 'common/styles/button';
 import { CandidateTableItem, useCandidateTableData } from '../hooks/useCandidateTableData';
 
 import { usePSFQuery } from 'common/hooks';
-import { PaginatedResult, Candidate } from 'common/models';
-import { useGetCandidatesQuery } from 'common/api/candidateApi';
+import { PaginatedResult, Candidate, Department } from 'common/models';
+import { useGetCandidatesQuery, useGetDepartmentsQuery } from 'common/api/candidateApi';
 import { DataTable } from 'common/components/DataTable';
 import { DataTableSearchAndFilters } from 'common/components/DataTable/DataTableSearchAndFilters';
 import { WithLoadingOverlay } from 'common/components/LoadingSpinner';
@@ -40,6 +40,9 @@ export const CandidateListView: FC = () => {
     resetFilters,
     addSearchText,
   } = usePSFQuery<PaginatedResult<Candidate>>(useGetCandidatesQuery);
+  const deptResults = usePSFQuery<PaginatedResult<Department>>(useGetDepartmentsQuery);
+  // console.log('dept results', deptResults);
+  const departments = useMemo(() => deptResults.data?.results ?? [], [deptResults.data] )
   const candidates = useMemo(() => data?.results ?? [], [data]);
   const { columns, data: tableData } = useCandidateTableData(candidates);
   const isPageLoading = isLoading;

--- a/application/src/features/candidates/pages/CandidateListView.tsx
+++ b/application/src/features/candidates/pages/CandidateListView.tsx
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { Trans } from 'react-i18next';
 import { FC, useMemo } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { PageHeader } from 'common/styles/page';
 import { TableCard } from 'common/styles/card';
@@ -26,6 +26,7 @@ import { HasPermission } from 'features/rbac';
 
 
 export const CandidateListView: FC = () => {
+  const navigate = useNavigate();
   const {
     data,
     isLoading,
@@ -93,7 +94,7 @@ export const CandidateListView: FC = () => {
                 <DataTable<CandidateTableItem>
                   columns={columns}
                   data={tableData}
-                  onRowClick={() => {}}
+                  onRowClick={item => navigate(`/candidates/update-candidate/${item.id}`)}
                   pagination={{
                     basePage: 1,
                     page,

--- a/application/src/features/candidates/pages/CandidateListView.tsx
+++ b/application/src/features/candidates/pages/CandidateListView.tsx
@@ -8,6 +8,7 @@ import { FC, useMemo } from 'react';
 import { PageHeader } from 'common/styles/page';
 import { TableCard } from 'common/styles/card';
 import { NoContent } from 'common/styles/utilities';
+import { CreateButton } from 'common/styles/button';
 
 import { CandidateTableItem, useCandidateTableData } from '../hooks/useCandidateTableData';
 
@@ -57,8 +58,18 @@ export const CandidateListView: FC = () => {
           <h1>
             <Trans i18nKey='candidateList.heading'>Candidate List</Trans>
           </h1>
+          <p>
+            <Trans i18nKey='candidateList.subheading'>All candidates in the system</Trans>
+          </p>
+          <div>
+            {/* <Link to='/users/create-user'> */}
+              <CreateButton>
+                <Trans i18nKey='candidateList.createButton'>Add Candidate</Trans>
+              </CreateButton>
+            {/* </Link> */}
+          </div>
         </div>
-
+        </PageHeader>
         <DataTableSearchAndFilters
           filters={filters}
           onSetFilter={addFilter}
@@ -103,7 +114,7 @@ export const CandidateListView: FC = () => {
             </WithLoadingOverlay>
           </Card.Body>
         </TableCard>
-      </PageHeader>
+      
     </Container>
   )
 }

--- a/application/src/features/candidates/pages/CandidateListView.tsx
+++ b/application/src/features/candidates/pages/CandidateListView.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { Trans } from 'react-i18next';
 import { FC, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 
 import { PageHeader } from 'common/styles/page';
 import { TableCard } from 'common/styles/card';
@@ -62,11 +63,11 @@ export const CandidateListView: FC = () => {
             <Trans i18nKey='candidateList.subheading'>All candidates in the system</Trans>
           </p>
           <div>
-            {/* <Link to='/users/create-user'> */}
+            <Link to='/candidates/create-candidate'>
               <CreateButton>
                 <Trans i18nKey='candidateList.createButton'>Add Candidate</Trans>
               </CreateButton>
-            {/* </Link> */}
+            </Link>
           </div>
         </div>
         </PageHeader>

--- a/application/src/features/candidates/pages/CreateCandidateView.tsx
+++ b/application/src/features/candidates/pages/CreateCandidateView.tsx
@@ -1,0 +1,48 @@
+import { FC } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Trans } from 'react-i18next';
+import { Card } from 'react-bootstrap';
+import { Link, useNavigate } from 'react-router-dom';
+
+
+import { PageCrumb, PageHeader, SmallContainer } from 'common/styles/page';
+
+
+export const CreateCandidateView: FC = () => {
+  return (
+    <SmallContainer>
+      <PageCrumb>
+        <Link to='/candidates'>
+          <>
+            <FontAwesomeIcon icon={['fas', 'chevron-left']} />
+            <Trans i18nKey='createCandidate.back'>Back to Candidate List</Trans>
+          </>
+        </Link>
+      </PageCrumb>
+
+      <PageHeader>
+        <div>
+          <h1>
+            <Trans i18nKey='createCandidate.heading'>Create Candidate</Trans>
+          </h1>
+          <p className='text-muted'>
+            <Trans i18nKey='createCandidate.subheading'>Add a new candidate to the system.</Trans>
+          </p>
+        </div>
+      </PageHeader>
+
+      <Card>
+        <Card.Body>
+          <p>Insert Candidate Form here</p>
+          {/* <UserDetailForm
+            availableRoles={availableRoles}
+            defaultValues={defaultValues}
+            submitButtonLabel='Create'
+            onSubmit={handleFormSubmit}
+            serverValidationErrors={formValidationErrors}
+          /> */}
+        </Card.Body>
+      </Card>
+    </SmallContainer>
+  );
+}

--- a/application/src/features/candidates/pages/CreateCandidateView.tsx
+++ b/application/src/features/candidates/pages/CreateCandidateView.tsx
@@ -1,14 +1,23 @@
-import { FC } from 'react';
+import { FC, useState, useMemo } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from 'react-i18next';
 import { Card } from 'react-bootstrap';
 import { Link, useNavigate } from 'react-router-dom';
 
+import { CandidateDetailForm, FormData } from '../components/candidateDetailForm';
+import { useGetDepartmentsQuery } from 'common/api/candidateApi';
+import { PaginatedResult, ServerValidationErrors, Department } from 'common/models';
+import { usePSFQuery } from 'common/hooks';
 
 import { PageCrumb, PageHeader, SmallContainer } from 'common/styles/page';
 
 
 export const CreateCandidateView: FC = () => {
+
+  const [formValidationErrors, setFormValidationErrors] = useState<ServerValidationErrors<FormData> | null>(null);
+  const deptResults = usePSFQuery<PaginatedResult<Department>>(useGetDepartmentsQuery);
+  const departments = useMemo(() => deptResults.data?.results ?? [], [deptResults.data] )
+
   return (
     <SmallContainer>
       <PageCrumb>
@@ -34,6 +43,12 @@ export const CreateCandidateView: FC = () => {
       <Card>
         <Card.Body>
           <p>Insert Candidate Form here</p>
+          <CandidateDetailForm 
+            onSubmit={() => {}}
+            serverValidationErrors={formValidationErrors}
+            onCancel={() => {}}
+            departmentList={departments}
+          />
           {/* <UserDetailForm
             availableRoles={availableRoles}
             defaultValues={defaultValues}

--- a/application/src/features/candidates/pages/UpdateCandidateView.tsx
+++ b/application/src/features/candidates/pages/UpdateCandidateView.tsx
@@ -4,14 +4,14 @@ import { isFetchBaseQueryError } from 'common/api/handleApiError';
 import { WithLoadingOverlay } from 'common/components/LoadingSpinner';
 import { isObject } from 'common/error/utilities';
 import { usePSFQuery } from 'common/hooks';
-import { Department, PaginatedResult, ServerValidationErrors } from 'common/models';
+import { Department, Candidate, PaginatedResult, ServerValidationErrors } from 'common/models';
 import * as notificationService from 'common/services/notification';
 import { PageCrumb, SmallContainer, PageHeader } from 'common/styles/page';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { Card } from 'react-bootstrap';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 
-import { CandidateDetailForm, FormData } from '../components/candidateDetailForm';
+import { CandidateDetailForm, FormData, CandidateFormData } from '../components/candidateDetailForm';
 
 export type RouteParams = {
     id: string;
@@ -54,6 +54,18 @@ export const UpdateCandidateView: FC = () => {
     }
   };
 
+  const handleCandidateData = (candidate: Candidate | undefined) => {
+    const result: CandidateFormData | undefined = candidate && candidate.department && candidate.department.id ?
+    {
+      id: candidate.id,
+      name: candidate.name,
+      email: candidate.email,
+      department: candidate.department.id
+    } :
+    undefined;
+    return result;
+  }
+
   return (
     <SmallContainer>
       <PageCrumb>
@@ -77,7 +89,7 @@ export const UpdateCandidateView: FC = () => {
           >
             {!isLoadingCandidate ? (
               <CandidateDetailForm
-                defaultValues={candidate}
+                defaultValues={handleCandidateData(candidate)}
                 submitButtonLabel='Save'
                 onSubmit={handleFormSubmit}
                 onCancel={handleFormCancel}

--- a/application/src/features/candidates/pages/UpdateCandidateView.tsx
+++ b/application/src/features/candidates/pages/UpdateCandidateView.tsx
@@ -1,0 +1,94 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useGetCandidateByIdQuery, useGetDepartmentsQuery, useUpdateCandidateMutation } from 'common/api/candidateApi';
+import { isFetchBaseQueryError } from 'common/api/handleApiError';
+import { WithLoadingOverlay } from 'common/components/LoadingSpinner';
+import { isObject } from 'common/error/utilities';
+import { usePSFQuery } from 'common/hooks';
+import { Department, PaginatedResult, ServerValidationErrors } from 'common/models';
+import * as notificationService from 'common/services/notification';
+import { PageCrumb, SmallContainer, PageHeader } from 'common/styles/page';
+import { FC, useEffect, useMemo, useState } from 'react';
+import { Card } from 'react-bootstrap';
+import { useNavigate, useParams, Link } from 'react-router-dom';
+
+import { CandidateDetailForm, FormData } from '../components/candidateDetailForm';
+
+export type RouteParams = {
+    id: string;
+};
+
+export const UpdateCandidateView: FC = () => {
+  const { id } = useParams<RouteParams>();
+  const navigate = useNavigate();
+  const [updateCandidate] = useUpdateCandidateMutation();
+  const { data: candidate, isLoading: isLoadingCandidate, isFetching, error } = useGetCandidateByIdQuery(id!);
+  const [formValidationErrors, setFormValidationErrors] = useState<ServerValidationErrors<FormData> | null>(null)
+  const deptResults = usePSFQuery<PaginatedResult<Department>>(useGetDepartmentsQuery);
+  const departments = useMemo(() => deptResults.data?.results ?? [], [deptResults.data] )
+
+  useEffect(() => {
+    if (error) {
+      notificationService.showErrorMessage('Unable to load candidate. Returning to candidate list.');
+      navigate('/candidates', { replace: true });
+    }
+  }, [error, navigate]);
+
+  const handleFormCancel = () => {
+    navigate(-1);
+  }
+  const handleFormSubmit = async (data: FormData) => {
+    const updateRequest = { id: Number(id), ...data };
+    try {
+      await updateCandidate(updateRequest).unwrap();
+      notificationService.showSuccessMessage('Candidate updated');
+      navigate('/candidates');
+    } catch (error) {
+      notificationService.showErrorMessage('Unable to update candidate');
+      if (error && isFetchBaseQueryError(error)) {
+        if (isObject(error.data)) {
+          setFormValidationErrors(error.data);
+        }
+      } else {
+        throw error;
+      }
+    }
+  };
+
+  return (
+    <SmallContainer>
+      <PageCrumb>
+        <Link to='/candidates'>
+          <FontAwesomeIcon icon={['fas', 'chevron-left']} /> Back to Candidate List
+        </Link>
+      </PageCrumb>
+      <PageHeader>
+        <div>
+          <h1>Edit Candidate</h1>
+          <p className="text-muted">Update this candidate's details here.</p>
+        </div>
+      </PageHeader>
+      <Card>
+        <Card.Body>
+          <WithLoadingOverlay
+            isInitialLoad={isLoadingCandidate && isFetching}
+            isLoading={isLoadingCandidate}
+            containerHasRoundedCorners
+            containerBorderRadius='6px'
+          >
+            {!isLoadingCandidate ? (
+              <CandidateDetailForm
+                defaultValues={candidate}
+                submitButtonLabel='Save'
+                onSubmit={handleFormSubmit}
+                onCancel={handleFormCancel}
+                serverValidationErrors={formValidationErrors}
+                departmentList={departments}
+              />
+            ) : null}
+          </WithLoadingOverlay>
+        </Card.Body>
+      </Card>
+    </SmallContainer>
+  );
+
+}

--- a/application/src/features/candidates/pages/index.ts
+++ b/application/src/features/candidates/pages/index.ts
@@ -1,1 +1,2 @@
 export * from './CandidateListView';
+export * from './CreateCandidateView';

--- a/application/src/features/candidates/pages/index.ts
+++ b/application/src/features/candidates/pages/index.ts
@@ -1,2 +1,3 @@
 export * from './CandidateListView';
 export * from './CreateCandidateView';
+export * from './UpdateCandidateView';

--- a/application/src/i18n/en/translation.json
+++ b/application/src/i18n/en/translation.json
@@ -5,7 +5,9 @@
     "createButton": "Add Agent"
   },
   "candidateList": {
-    "heading": "Candidate List"
+    "heading": "Candidate List",
+    "subheading": "All candidates in the system",
+    "createButton": "Add Candidate"
   },
   "userDetail": {
     "heading": "Profile",

--- a/application/src/i18n/en/translation.json
+++ b/application/src/i18n/en/translation.json
@@ -22,6 +22,11 @@
     "heading": "Create User",
     "subheading": "Add a new user to the system."
   },
+  "createCandidate": {
+    "back": "Back to Candidate List",
+    "heading": "Create Candidate",
+    "subheading": "Add a new candidate to the system"
+  },
   "updateUser": {
     "heading": "Update User",
     "subheading": "Update this users details and roles here."

--- a/server/server/candidates/serializers.py
+++ b/server/server/candidates/serializers.py
@@ -11,7 +11,8 @@ class DepartmentSerializer(serializers.ModelSerializer):
         fields = [
             "dept_name",
             "contact",
-            "contact_email"
+            "contact_email",
+            "id"
         ]
 
 class CandidateSerializer(serializers.ModelSerializer):

--- a/server/server/candidates/serializers.py
+++ b/server/server/candidates/serializers.py
@@ -15,7 +15,7 @@ class DepartmentSerializer(serializers.ModelSerializer):
         ]
 
 class CandidateSerializer(serializers.ModelSerializer):
-    department = DepartmentSerializer()
+    department = DepartmentSerializer(read_only=True, many=False)
     class Meta:
         model = Candidate
         fields = [


### PR DESCRIPTION
Adds create/edit/delete functionality. Mostly mirrors the agent form in structure. A couple of differences:

- A query is made to get a list of departments to populate the dropdown
- Adjustment to the data needs to be made as the query for an individual candidate populates the department info whereas the data for the form and the update query only wants the foreign key. Keeping everything type safe during this conversion was the biggest challenge.
- A couple of the API routes had typos

Delete functionality worked right out of the box by more or less copying how the agent delete button works.